### PR TITLE
Add history view and stabilize session logging

### DIFF
--- a/src/components/ActiveSessionScreen.tsx
+++ b/src/components/ActiveSessionScreen.tsx
@@ -7,23 +7,31 @@ import { generateCsv } from '../utils/csvExport';
 
 export const ActiveSessionScreen: React.FC = () => {
     const {
-        boomLogs, addBoomLog, updateBoomLog, deleteBoomLog, endSession
+        boomLogs,
+        addBoomLog,
+        updateBoomLog,
+        deleteBoomLog,
+        endSession,
+        sessionStartTime,
+        sessionDate,
     } = useSessionStore();
 
     const [elapsedTime, setElapsedTime] = useState(0);
     const [editingLogId, setEditingLogId] = useState<string | null>(null);
 
     useEffect(() => {
+        const start = new Date(`${sessionDate}T${sessionStartTime || '00:00:00'}`);
+        const startMs = isNaN(start.getTime()) ? Date.now() : start.getTime();
+
+        const calculateElapsed = () => Math.max(0, Math.floor((Date.now() - startMs) / 1000));
+
+        setElapsedTime(calculateElapsed());
+
         const interval = setInterval(() => {
-            // Simple elapsed time for now, ideally compare with sessionStartTime
-            // But sessionStartTime is a string HH:MM:SS, so we might need a proper Date object in store or just count seconds here for display
-            // For MVP, let's just increment a counter or parse the start time if needed.
-            // Let's just show a countdown from 60 mins based on start time?
-            // For simplicity, I'll just show a timer that runs.
-            setElapsedTime(prev => prev + 1);
+            setElapsedTime(calculateElapsed());
         }, 1000);
         return () => clearInterval(interval);
-    }, []);
+    }, [sessionDate, sessionStartTime]);
 
     const formatTime = (seconds: number) => {
         const mins = Math.floor(seconds / 60);

--- a/src/components/HistoryView.tsx
+++ b/src/components/HistoryView.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useSessionStore } from '../store/sessionStore';
+
+export const HistoryView: React.FC = () => {
+    const {
+        boomLogs,
+        environmentalLogs,
+        observerId,
+        sessionDate,
+        stationLat,
+        stationLon,
+        sunsetTime,
+    } = useSessionStore();
+
+    return (
+        <div className="p-4 space-y-4 max-w-md mx-auto">
+            <div className="bg-slate-800 rounded-lg p-4 border border-slate-700 space-y-1">
+                <h2 className="text-lg font-semibold text-emerald-400">Session Overview</h2>
+                <p className="text-slate-200">Observer: {observerId || 'Not set'}</p>
+                <p className="text-slate-200">Date: {sessionDate}</p>
+                <p className="text-slate-200">Location: {stationLat.toFixed(4)}, {stationLon.toFixed(4)}</p>
+                <p className="text-slate-200">Sunset: {sunsetTime || '--:--'}</p>
+            </div>
+
+            <div className="bg-slate-800 rounded-lg p-4 border border-slate-700">
+                <h3 className="text-md font-semibold text-slate-100 mb-2">Environmental Logs</h3>
+                {environmentalLogs.length === 0 && (
+                    <p className="text-slate-500 text-sm">No environmental logs recorded yet.</p>
+                )}
+                <ul className="space-y-2">
+                    {environmentalLogs.map((env) => (
+                        <li key={env.timestamp} className="bg-slate-900/50 p-3 rounded border border-slate-700 text-sm text-slate-200">
+                            <div className="font-semibold text-white">{env.timestamp}</div>
+                            <div className="grid grid-cols-2 gap-1 text-slate-300 mt-1">
+                                <span>Noise: {env.noiseLevel}</span>
+                                <span>Wind: {env.windStrength}</span>
+                                <span>Moon: {env.moonVisibility}</span>
+                                <span>Cloud: {env.cloudCover}</span>
+                                <span>Rain: {env.rainPresence}</span>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+
+            <div className="bg-slate-800 rounded-lg p-4 border border-slate-700">
+                <h3 className="text-md font-semibold text-slate-100 mb-2">Boom Logs</h3>
+                {boomLogs.length === 0 && (
+                    <p className="text-slate-500 text-sm">No boom logs recorded yet.</p>
+                )}
+                <ul className="space-y-2">
+                    {boomLogs.map((boom) => (
+                        <li key={boom.id} className="bg-slate-900/50 p-3 rounded border border-slate-700 text-sm text-slate-200">
+                            <div className="flex justify-between items-center">
+                                <span className="font-semibold text-white">{boom.callTimestamp}</span>
+                                <span className="text-xs text-slate-400">Bittern ID: {boom.bitternId || 'n/a'}</span>
+                            </div>
+                            <div className="grid grid-cols-3 gap-1 mt-1 text-slate-300">
+                                <span>{boom.boomCount} booms</span>
+                                <span>{boom.compassBearing}°</span>
+                                <span>{boom.estDistanceM} m</span>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/src/components/SetupScreen.tsx
+++ b/src/components/SetupScreen.tsx
@@ -79,6 +79,11 @@ export const SetupScreen: React.FC = () => {
                     <Sun size={18} />
                     <span>Sunset: {useSessionStore.getState().sunsetTime || '--:--'}</span>
                 </div>
+                {(locationStatus.startsWith('GPS Error') || locationStatus === 'Geolocation not supported') && (
+                    <p className="text-sm text-amber-300">
+                        GPS did not lock on, but you can still start logging and update coordinates in the CSV later if needed.
+                    </p>
+                )}
             </div>
 
             <div className="space-y-4">

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -64,12 +64,23 @@ export const generateCsv = (session: SessionData): string => {
 
     // const initialEnv = session.environmentalLogs[0] || {};
 
+    const fallbackEnv = {
+        timestamp: '',
+        noiseLevel: '',
+        windStrength: '',
+        moonVisibility: '',
+        cloudCover: '',
+        rainPresence: '',
+    } as const;
+
     session.boomLogs.forEach(boom => {
         // Find applicable env log (closest before boom)
         // For MVP just use the first one or the last one before boom.
-        const env = session.environmentalLogs.reduce((prev, curr) => {
-            return curr.timestamp <= boom.callTimestamp ? curr : prev;
-        }, session.environmentalLogs[0]);
+        const env = session.environmentalLogs.length
+            ? session.environmentalLogs.reduce((prev, curr) => {
+                return curr.timestamp <= boom.callTimestamp ? curr : prev;
+            }, session.environmentalLogs[0])
+            : fallbackEnv;
 
         const row = [
             session.observerId,


### PR DESCRIPTION
## Summary
- add a History tab that surfaces session details along with environmental and boom logs
- tie the active session timer to the stored start time and clarify GPS failure fallback messaging
- guard CSV export when no environmental logs are present to avoid runtime errors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282ba1ac78832e88c91ff8b343c2db)