### PR TITLE
Fix duplicate destructuring in ActiveSessionScreen

### DIFF
--- a/src/components/ActiveSessionScreen.tsx
+++ b/src/components/ActiveSessionScreen.tsx
@@ -21,10 +21,6 @@ export const ActiveSessionScreen: React.FC<ActiveSessionScreenProps> = ({ onShow
         nextBitternId,
         lastSelectedBitternId,
         selectBitternId,
-        deleteBoomLog,
-        endSession,
-        sessionStartTime,
-        sessionDate,
     } = useSessionStore();
 
     const [elapsedTime, setElapsedTime] = useState(0);


### PR DESCRIPTION
## Summary
- remove duplicate destructuring entries in ActiveSessionScreen to avoid redeclared variables

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286217d9c0832e83a7248f31bb09e9)