### PR TITLE
Fix compass direction rounding

### DIFF
--- a/src/components/CompassDial.tsx
+++ b/src/components/CompassDial.tsx
@@ -16,7 +16,8 @@ const snapAngle = (angle: number, step: number) => {
 
 export const getDirectionLabel = (angle: number) => {
     const sectorSize = 360 / DIRECTIONS.length; // 22.5°
-    const index = Math.round(((angle % 360) + sectorSize / 2) / sectorSize) % DIRECTIONS.length;
+    const normalizedAngle = ((angle % 360) + 360) % 360;
+    const index = Math.floor((normalizedAngle + sectorSize / 2) / sectorSize) % DIRECTIONS.length;
     return DIRECTIONS[index];
 };
 


### PR DESCRIPTION
## Summary
- correct compass direction label rounding so cardinal bearings map to expected headings

## Testing
- npm run lint *(fails: eslint config export error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69287cb7c8f0832eb97af17a65923a0b)