### PR TITLE
Fix compass heading calculation

### DIFF
--- a/src/components/CompassDial.tsx
+++ b/src/components/CompassDial.tsx
@@ -42,18 +42,9 @@ export const CompassDial: React.FC<CompassDialProps> = ({ value, onChange, size 
             const x = event.clientX - rect.left - rect.width / 2;
             const y = event.clientY - rect.top - rect.height / 2;
 
-            // 1. Calculate standard Cartesian angle (0 deg = East, CCW)
-            const angleInRad = Math.atan2(y, x);
-            let degrees = (angleInRad * 180) / Math.PI;
+            const normalizedAngle = pointerToHeading(x, y);
 
-            // 2. Correct for Compass Bearings (0 deg = North, Clockwise)
-            // Shift by 90 degrees and reverse rotation
-            degrees = 90 - degrees;
-
-            // 3. Normalize to 0-360 range
-            const normalizedAngle = (degrees + 360) % 360; 
-
-            // 4. Snap and update
+            // Snap and update
             const snapped = snapAngle(normalizedAngle, 10);
             onChange(snapped);
         },


### PR DESCRIPTION
## Summary
- reuse the shared heading helper for pointer movement so clockwise dragging increases bearings
- retain snapping to 10° increments after the corrected heading calculation

## Testing
- npm run lint *(fails: ESLint package exports error with eslint.config.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b09ed9720832eba1c15824e62d47e)